### PR TITLE
Transactions Support from Client SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ A simple library aiming to make working with MongoDB from the frontend simple an
 
 ### Good to Have
 
-- FireStore like ArrayUnion, ArrayRemove, serverTimestamp and delete ops.
+Some good features that Firestore's SDK supports that can find their way into MBlaze:
+
+- FireStore like ArrayUnion, ArrayRemove, Atomic increment, serverTimestamp data types and field delete op.
 - Any other features Firestore's SDK might have that isn't supported by MBlaze.
 
 If you would like to contribute on any of the above, feel free to fork the repo and raise a Pull Request for your feature.

--- a/library/client/README.md
+++ b/library/client/README.md
@@ -180,3 +180,21 @@ const db = new DB(BACKEND_MONGODB_ENDPOINT, ({
 	return { headers: ... }
 });
 ```
+
+---
+
+### Transactions
+
+As long as your [backend MongoDB setup supports Transactions](../express/README.md#transactions), you can run them using the `db.runTransaction` method.
+
+> **Only write operations are supported for transactions. Read operations are not atomic/guaranteed because the first time the backend is informed of a transaction, it's when `transaction.save` is called.**
+
+```javascript
+db.runTransaction((transaction) => {
+	transaction.update(docRef, { newField: "value" });
+	transaction.delete(docToDeleteRef);
+	transaction.set(docToCreateRef, { newDoc: "newValue" });
+
+	transaction.save(); // Mandatory, otherwise the transaction is never registered.
+});
+```

--- a/library/client/package.json
+++ b/library/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mblaze.client",
-	"version": "2.1.1",
+	"version": "3.0.0",
 	"description": "",
 	"main": "index.js",
 	"repository": "https://github.com/deve-sh/mblaze/tree/main/library/client",

--- a/library/client/src/classes/DB.ts
+++ b/library/client/src/classes/DB.ts
@@ -3,6 +3,8 @@ import DocRef from "./DocRef";
 import setBackendEndpoint from "../utils/setBackendEndpoint";
 import type RequestCommonConfig from "../types/RequestCommonConfig";
 import setRequestConfig from "../utils/setRequestConfig";
+import type TransactionCallback from "../types/TransactionCallback";
+import Transaction from "./Transaction";
 
 class DB {
 	constructor(backendEndpoint: string, requestConfig?: RequestCommonConfig) {
@@ -28,6 +30,11 @@ class DB {
 			throw new Error("Document ID not provided.");
 		const [collectionName, docId] = collectionPlusDocId.split("/");
 		return new DocRef(collectionName, docId);
+	}
+
+	public runTransaction(callback: TransactionCallback) {
+		const transaction = new Transaction();
+		return callback(transaction);
 	}
 }
 

--- a/library/client/src/classes/DocRef.ts
+++ b/library/client/src/classes/DocRef.ts
@@ -1,7 +1,11 @@
 import ObjectId from "bson-objectid";
-import FetchedDoc from "./FetchedDoc";
-import sendSingleOpRequest from "../utils/sendSingleOpRequest";
-import MBlazeException from "../utils/mblazeError";
+
+import {
+	docDeleteRequest,
+	docGetRequest,
+	docSetRequest,
+	docUpdateRequest,
+} from "../requests/docRequests";
 
 class DocRef {
 	public collectionName: string;
@@ -17,67 +21,22 @@ class DocRef {
 	}
 
 	async get() {
-		const result = await sendSingleOpRequest({
-			operation: "get",
-			id: this.id,
-			collectionName: this.collectionName,
-		});
-		if (result.error && result.errorStatus !== 404)
-			throw new MBlazeException(
-				result.errorMessage || result.error.message,
-				result.errorStatus,
-				result.errorResponse
-			);
-		return new FetchedDoc(
-			this.collectionName,
-			this.id,
-			result.errorStatus === 404 ? null : result.response?.data || null
-		);
+		return docGetRequest(this);
 	}
 
-	async set(newData: Record<string, any>, { merge }: { merge: boolean }) {
-		const result = await sendSingleOpRequest({
-			operation: "set",
-			id: this.id,
-			collectionName: this.collectionName,
-			newData,
-			merge,
-		});
-		if (result.error)
-			throw new MBlazeException(
-				result.errorMessage || result.error.message,
-				result.errorStatus,
-				result.errorResponse
-			);
+	async set(
+		newData: Record<string, any>,
+		{ merge = false }: { merge: boolean }
+	) {
+		return docSetRequest(this, newData, { merge });
 	}
 
 	async update(updates: Record<string, any>) {
-		const result = await sendSingleOpRequest({
-			operation: "update",
-			id: this.id,
-			collectionName: this.collectionName,
-			newData: updates,
-		});
-		if (result.error)
-			throw new MBlazeException(
-				result.errorMessage || result.error.message,
-				result.errorStatus,
-				result.errorResponse
-			);
+		return docUpdateRequest(this, updates);
 	}
 
 	async delete() {
-		const result = await sendSingleOpRequest({
-			operation: "delete",
-			id: this.id,
-			collectionName: this.collectionName,
-		});
-		if (result.error)
-			throw new MBlazeException(
-				result.errorMessage || result.error.message,
-				result.errorStatus,
-				result.errorResponse
-			);
+		return docDeleteRequest(this);
 	}
 }
 

--- a/library/client/src/classes/DocRef.ts
+++ b/library/client/src/classes/DocRef.ts
@@ -10,7 +10,6 @@ import {
 class DocRef {
 	public collectionName: string;
 	public id: string;
-	public deleted: boolean = false;
 
 	constructor(collectionName: string, docId?: string) {
 		if (!collectionName)

--- a/library/client/src/classes/Transaction.ts
+++ b/library/client/src/classes/Transaction.ts
@@ -1,25 +1,54 @@
 import type OpRequesterArgs from "../types/OpRequesterArgs";
 import DocRef from "./DocRef";
 
+import {
+	docDeleteRequest,
+	docSetRequest,
+	docUpdateRequest,
+} from "../requests/docRequests";
+import { sendTransactionRequest } from "../utils/sendOpRequest";
+import MBlazeException from "../utils/mblazeError";
+
 class Transaction {
 	operationsList: Array<OpRequesterArgs>;
 	constructor() {
 		this.operationsList = [];
 	}
 
-	public get(ref: DocRef) {}
+	public get(ref: DocRef) {
+		return ref.get();
+	}
 
-	public update(ref: DocRef, updates: Record<string, any>) {}
+	public update(ref: DocRef, updates: Record<string, any>) {
+		docUpdateRequest(ref, updates, this.operationsList);
+	}
 
 	public set(
 		ref: DocRef,
 		newData: Record<string, any>,
-		{ merge }: { merge: boolean }
-	) {}
+		{ merge = false }: { merge: boolean }
+	) {
+		docSetRequest(ref, newData, { merge }, this.operationsList);
+	}
 
-	public delete(ref: DocRef) {}
+	public delete(ref: DocRef) {
+		docDeleteRequest(ref, this.operationsList);
+	}
 
-	public save() {}
+	public async save() {
+		if (!this.operationsList.length)
+			throw new MBlazeException(
+				"Transactions require at least one update/set/delete operation."
+			);
+		const result = await sendTransactionRequest(this.operationsList);
+		if (result.error)
+			throw new MBlazeException(
+				result.errorMessage || result.error.message,
+				result.errorStatus,
+				result.errorResponse
+			);
+		return result;
+	}
 }
 
 export default Transaction;

--- a/library/client/src/classes/Transaction.ts
+++ b/library/client/src/classes/Transaction.ts
@@ -1,0 +1,25 @@
+import type OpRequesterArgs from "../types/OpRequesterArgs";
+import DocRef from "./DocRef";
+
+class Transaction {
+	operationsList: Array<OpRequesterArgs>;
+	constructor() {
+		this.operationsList = [];
+	}
+
+	public get(ref: DocRef) {}
+
+	public update(ref: DocRef, updates: Record<string, any>) {}
+
+	public set(
+		ref: DocRef,
+		newData: Record<string, any>,
+		{ merge }: { merge: boolean }
+	) {}
+
+	public delete(ref: DocRef) {}
+
+	public save() {}
+}
+
+export default Transaction;

--- a/library/client/src/classes/Transaction.ts
+++ b/library/client/src/classes/Transaction.ts
@@ -10,16 +10,30 @@ import { sendTransactionRequest } from "../utils/sendOpRequest";
 import MBlazeException from "../utils/mblazeError";
 
 class Transaction {
-	operationsList: Array<OpRequesterArgs>;
+	private operationsList: Array<OpRequesterArgs>;
+	private saving: boolean;
+	private completed: boolean;
 	constructor() {
 		this.operationsList = [];
+		this.saving = false;
+		this.completed = false;
+	}
+
+	private canRunOps() {
+		return !this.completed && !this.saving;
+	}
+
+	private logCannotRunOpsError() {
+		return console.error("Transaction is processing or completed");
 	}
 
 	public get(ref: DocRef) {
+		if (!this.canRunOps()) return this.logCannotRunOpsError();
 		return ref.get();
 	}
 
 	public update(ref: DocRef, updates: Record<string, any>) {
+		if (!this.canRunOps()) return this.logCannotRunOpsError();
 		docUpdateRequest(ref, updates, this.operationsList);
 	}
 
@@ -28,10 +42,12 @@ class Transaction {
 		newData: Record<string, any>,
 		{ merge = false }: { merge: boolean }
 	) {
+		if (!this.canRunOps()) return this.logCannotRunOpsError();
 		docSetRequest(ref, newData, { merge }, this.operationsList);
 	}
 
 	public delete(ref: DocRef) {
+		if (!this.canRunOps()) return this.logCannotRunOpsError();
 		docDeleteRequest(ref, this.operationsList);
 	}
 
@@ -40,7 +56,10 @@ class Transaction {
 			throw new MBlazeException(
 				"Transactions require at least one update/set/delete operation."
 			);
+		this.saving = true; // Lock further ops from happening.
 		const result = await sendTransactionRequest(this.operationsList);
+		this.saving = false;
+		this.completed = true;
 		if (result.error)
 			throw new MBlazeException(
 				result.errorMessage || result.error.message,

--- a/library/client/src/requests/collectionGetRequest.ts
+++ b/library/client/src/requests/collectionGetRequest.ts
@@ -1,6 +1,6 @@
 import FetchedCollection from "../classes/FetchedCollection";
 import MBlazeException from "../utils/mblazeError";
-import sendSingleOpRequest from "../utils/sendSingleOpRequest";
+import { sendSingleOpRequest } from "../utils/sendOpRequest";
 
 interface CollectionGetRequestArg {
 	collectionName: string;

--- a/library/client/src/requests/docRequests.ts
+++ b/library/client/src/requests/docRequests.ts
@@ -1,9 +1,12 @@
 import DocRef from "../classes/DocRef";
 import FetchedDoc from "../classes/FetchedDoc";
 
-import sendSingleOpRequest from "../utils/sendSingleOpRequest";
+import { sendSingleOpRequest } from "../utils/sendOpRequest";
 import MBlazeException from "../utils/mblazeError";
 import OpRequesterArgs from "../types/OpRequesterArgs";
+
+// Wherever operationsList is being used, we add the operation to an array as it is being used in a Transaction.
+// In a transaction we batch the op requests into a collection request payload and send it to the backend.
 
 export const docGetRequest = async (docRef: DocRef) => {
 	const result = await sendSingleOpRequest({

--- a/library/client/src/requests/docRequests.ts
+++ b/library/client/src/requests/docRequests.ts
@@ -1,0 +1,95 @@
+import DocRef from "../classes/DocRef";
+import FetchedDoc from "../classes/FetchedDoc";
+
+import sendSingleOpRequest from "../utils/sendSingleOpRequest";
+import MBlazeException from "../utils/mblazeError";
+import OpRequesterArgs from "../types/OpRequesterArgs";
+
+export const docGetRequest = async (docRef: DocRef) => {
+	const result = await sendSingleOpRequest({
+		operation: "get",
+		id: docRef.id,
+		collectionName: docRef.collectionName,
+	});
+	if (result.error && result.errorStatus !== 404)
+		throw new MBlazeException(
+			result.errorMessage || result.error.message,
+			result.errorStatus,
+			result.errorResponse
+		);
+	return new FetchedDoc(
+		docRef.collectionName,
+		docRef.id,
+		result.errorStatus === 404 ? null : result.response?.data || null
+	);
+};
+
+export const docUpdateRequest = async (
+	docRef: DocRef,
+	updates: Record<string, any>,
+	operationList?: Array<OpRequesterArgs>
+) => {
+	const operation = {
+		operation: "update",
+		id: docRef.id,
+		collectionName: docRef.collectionName,
+		newData: updates,
+	} as OpRequesterArgs;
+	if (operationList) return operationList.push(operation);
+
+	const result = await sendSingleOpRequest(operation);
+	if (result.error)
+		throw new MBlazeException(
+			result.errorMessage || result.error.message,
+			result.errorStatus,
+			result.errorResponse
+		);
+	return result;
+};
+
+export const docDeleteRequest = async (
+	docRef: DocRef,
+	operationList?: Array<OpRequesterArgs>
+) => {
+	const operation = {
+		operation: "delete",
+		id: docRef.id,
+		collectionName: docRef.collectionName,
+	} as OpRequesterArgs;
+	if (operationList) return operationList.push(operation);
+
+	const result = await sendSingleOpRequest(operation);
+	if (result.error)
+		throw new MBlazeException(
+			result.errorMessage || result.error.message,
+			result.errorStatus,
+			result.errorResponse
+		);
+	return result;
+};
+
+export const docSetRequest = async (
+	docRef: DocRef,
+	newData: Record<string, any>,
+	options?: { merge: boolean },
+	operationsList?: Array<OpRequesterArgs>
+) => {
+	const { merge = false } = options || {};
+	const operation = {
+		operation: "set",
+		id: docRef.id,
+		collectionName: docRef.collectionName,
+		newData,
+		merge,
+	} as OpRequesterArgs;
+	if (operationsList) return operationsList.push(operation);
+
+	const result = await sendSingleOpRequest(operation);
+	if (result.error)
+		throw new MBlazeException(
+			result.errorMessage || result.error.message,
+			result.errorStatus,
+			result.errorResponse
+		);
+	return result;
+};

--- a/library/client/src/types/RequestCommonConfig.ts
+++ b/library/client/src/types/RequestCommonConfig.ts
@@ -6,6 +6,6 @@ export type RequestConfig = {
 
 type RequestCommonConfig =
 	| RequestConfig
-	| ((args: OpRequesterArgs) => RequestConfig);
+	| ((args: OpRequesterArgs | Array<OpRequesterArgs>) => RequestConfig);
 
 export default RequestCommonConfig;

--- a/library/client/src/types/TransactionCallback.ts
+++ b/library/client/src/types/TransactionCallback.ts
@@ -1,0 +1,5 @@
+import Transaction from "../classes/Transaction";
+
+type TransactionCallback = (transaction: Transaction) => any;
+
+export default TransactionCallback;

--- a/library/client/src/utils/getRequestConfig.ts
+++ b/library/client/src/utils/getRequestConfig.ts
@@ -3,7 +3,9 @@ import RequestCommonConfig, {
 	RequestConfig,
 } from "../types/RequestCommonConfig";
 
-const getRequestConfig = (args: OpRequesterArgs): RequestConfig => {
+const getRequestConfig = (
+	args: OpRequesterArgs | Array<OpRequesterArgs>
+): RequestConfig => {
 	let requestCommonConfig;
 	if (typeof window === "undefined")
 		requestCommonConfig = (global as any)

--- a/library/client/src/utils/sendOpRequest.ts
+++ b/library/client/src/utils/sendOpRequest.ts
@@ -66,7 +66,7 @@ const handleResponse = ({
 	return { error: null, response: {} };
 };
 
-const sendSingleOpRequest = async (
+export const sendSingleOpRequest = async (
 	args: OpRequesterArgs
 ): Promise<opReturnType> => {
 	const {
@@ -115,4 +115,24 @@ const sendSingleOpRequest = async (
 	}
 };
 
-export default sendSingleOpRequest;
+export const sendTransactionRequest = async (
+	args: Array<OpRequesterArgs>
+): Promise<opReturnType> => {
+	try {
+		const backendEndpoint = getBackendEndpoint();
+		if (!backendEndpoint)
+			throw new Error(
+				"Backend endpoint not specified, please specify backend endpoint first using new MBlaze.DB(<backendEndpoint>)"
+			);
+		const requestBody: Array<Record<string, any>> = args;
+
+		const { headers = {} } = getRequestConfig(args) as RequestConfig;
+
+		const { data } = await axios.post(backendEndpoint, requestBody, {
+			headers,
+		});
+		return data;
+	} catch (error: any) {
+		return handleError(error);
+	}
+};

--- a/library/client/src/utils/sendSingleOpRequest.ts
+++ b/library/client/src/utils/sendSingleOpRequest.ts
@@ -6,7 +6,7 @@ import type { RequestConfig } from "../types/RequestCommonConfig";
 import getBackendEndpoint from "./getBackendEndpoint";
 import getRequestConfig from "./getRequestConfig";
 
-interface opReturnType {
+export interface opReturnType {
 	response: Record<string, any> | null;
 	error: Record<string, any> | null;
 	errorResponse?: Record<string, any>;


### PR DESCRIPTION
#### Changes Made:
- Request Operation Functions moved out of Doc Ref class.
- All Op Requester Functions have a new argument `operationsList` added to them. If it is present, the op takes the form of a transaction and instead of individual requests, they are batched into one request and sent.
- `sendSingleOpRequest` is now a named export instead, along with `sendTransactionRequest`.
- A transaction can be initialized using the `db.runTransaction` method, which takes a Transaction class instance as a callback and then makes the write operations and invokes `save` at the end.

```typescript
// Usage

db.runTransaction((transaction) => {
	transaction.update(docRef, { newField: "value" });
	transaction.delete(docToDeleteRef);
	transaction.set(docToCreateRef, { newDoc: "newValue" });

	transaction.save();
});
```